### PR TITLE
Force newline before pre-release note

### DIFF
--- a/template.go
+++ b/template.go
@@ -21,7 +21,7 @@ const (
 	releaseNotes        = `{{.ProjectName}} {{.Version}}
 
 Welcome to the {{.Tag}} release of {{.ProjectName}}!
-{{- if .PreRelease }}
+{{- if .PreRelease }}  {{/* two spaces added for markdown newline*/}}
 *This is a pre-release of {{.ProjectName}}*
 {{- end}}
 


### PR DESCRIPTION
Generated markdown will put the pre-release note on the same line unless a new line indicator is used. This seems to be a recent change in github markdown rendering. The "invisible" newline indicator used by markdown is two [spaces](https://en.wikipedia.org/wiki/Whitespace_(programming_language)).

From https://daringfireball.net/projects/markdown/syntax#p
> When you do want to insert a `<br />` break tag using Markdown, you end a line with two or more spaces

