### PR TITLE
Move to GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Release-Tool CI
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "::set-env name=GOPATH::${{ github.workspace }}"
+        echo "::add-path::${{ github.workspace }}/bin"
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/release-tool
+        fetch-depth: 25
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        repository: containerd/project
+        path: src/github.com/containerd/project
+
+    - name: Install dependencies
+      env:
+        GO111MODULE: off
+        GOLANGCI_LINT_VERSION: "v1.22.2"
+      run: |
+        go get -u github.com/vbatts/git-validation
+        go get -u github.com/kunalkushwaha/ltag
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+
+    - name: Check DCO/whitespace/commit message
+      env:
+        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+        DCO_VERBOSITY: "-q"
+        DCO_RANGE: ""
+      working-directory: src/github.com/containerd/release-tool
+      run: |
+        if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
+        else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+        fi
+        ../project/script/validate/dco
+
+    - name: Check file headers
+      run: ../project/script/validate/fileheader ../project/
+      working-directory: src/github.com/containerd/release-tool
+
+    - name: Vendor
+      run: ../project/script/validate/vendor
+      working-directory: src/github.com/containerd/release-tool
+
+    - name: Lint
+      run: GOGC=75 golangci-lint run
+      working-directory: src/github.com/containerd/release-tool
+
+    - name: Build
+      working-directory: src/github.com/containerd/release-tool
+      run: |
+        go build -o release-tool github.com/containerd/release-tool

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,0 @@
-github.com/sirupsen/logrus v1.0.0
-github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
-github.com/pkg/errors v0.8.0
-github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
-golang.org/x/sys 1b2967e3c290b7c545b3db0deeda16e9be4f98a2 https://github.com/golang/sys


### PR DESCRIPTION
Also corrects the fact that vendor checking had been turned off; the correct fix is to remove `vendor.conf` so that our common project vendor validation uses `go mod`.