### PR TITLE
Cleanup output when no previous version

### DIFF
--- a/template.go
+++ b/template.go
@@ -51,10 +51,17 @@ https://github.com/{{.GithubRepo}}/issues.
 {{- end}}
 
 ### Dependency Changes
-{{range $dep := .Dependencies}}
+{{if .Dependencies}}
+{{- range $dep := .Dependencies}}
 * **{{$dep.Name}}**	{{if $dep.Previous}}{{$dep.Previous}} -> {{$dep.Ref}}{{else}}{{$dep.Ref}} **_new_**{{end}}
 {{- end}}
+{{- else}}
+This release has no dependency changes
+{{- end}}
+
+{{- if .Previous}}
 
 Previous release can be found at [{{.Previous}}](https://github.com/{{.GithubRepo}}/releases/tag/{{.Previous}})
+{{- end}}
 `
 )


### PR DESCRIPTION
Remove dead link at bottom when no previous version.
Don't keep dependency section empty when no dependencies, mention no dependencies but keep section header for consistency.

This will help use this tool for projects reaching 1.0