### PR TITLE
Add remote call caching

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,59 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base32"
+	"hash/fnv"
+	"io/ioutil"
+	"path/filepath"
+)
+
+type Cache interface {
+	Get(string) ([]byte, bool)
+	Put(string, []byte) error
+}
+
+type nilCache struct{}
+
+func (nc nilCache) Get(string) ([]byte, bool) {
+	return nil, false
+}
+
+func (nc nilCache) Put(string, []byte) error {
+	return nil
+}
+
+type dirCache struct {
+	root string
+}
+
+func (dc *dirCache) Get(key string) ([]byte, bool) {
+	b, err := ioutil.ReadFile(dc.path(key))
+	return b, err == nil
+}
+
+func (dc *dirCache) Put(key string, value []byte) error {
+	return ioutil.WriteFile(dc.path(key), value, 0755)
+}
+
+func (dc *dirCache) path(key string) string {
+	h := fnv.New128a()
+	h.Write([]byte(key))
+	h.Sum(nil)
+	return filepath.Join(dc.root, base32.StdEncoding.EncodeToString(h.Sum(nil)))
+}


### PR DESCRIPTION
During the lifespan of a release, the release tool may be called many times to verify results and output. Each run may make remote calls which can easily be cached. Use a cache directory when provided for static requests.

Note: I've been using this change for awhile and during the last release cycle but noticed I hadn't opened a PR for this yet. It saves quite a bit of time.
