### PR TITLE
Use https:// instead of git://, because git:// is insecure

### DIFF
--- a/util.go
+++ b/util.go
@@ -335,11 +335,11 @@ func getGitURL(name string) string {
 	if idx := strings.Index(name, "/"); idx > 0 {
 		switch name[:idx] {
 		case "github.com":
-			return "git://" + name
+			return "https://" + name
 		case "k8s.io":
-			return "git://github.com/kubernetes" + name[idx:]
+			return "https://github.com/kubernetes" + name[idx:]
 		case "sigs.k8s.io":
-			return "git://github.com/kubernetes-sigs" + name[idx:]
+			return "https://github.com/kubernetes-sigs" + name[idx:]
 		case "gopkg.in":
 			// gopkg.in/pkg.v3      → github.com/go-pkg/pkg (branch/tag v3, v3.N, or v3.N.M)
 			// gopkg.in/user/pkg.v3 → github.com/user/pkg   (branch/tag v3, v3.N, or v3.N.M)

--- a/util_test.go
+++ b/util_test.go
@@ -46,13 +46,13 @@ func TestGetGitURL(t *testing.T) {
 		name string
 		git  string
 	}{
-		{"github.com/docker/distribution", "git://github.com/docker/distribution"},
-		{"sigs.k8s.io/yaml", "git://github.com/kubernetes-sigs/yaml"},
-		{"k8s.io/utils", "git://github.com/kubernetes/utils"},
-		{"k8s.io/client-go", "git://github.com/kubernetes/client-go"},
-		//{"gopkg.in/src-d/go-git.v4", "git://github.com/src-d/go-git"},
-		//{"golang.org/x/tools", "git://github.com/golang/tools"},
-		//{"golang.org/x/sync", "git://github.com/golang/sync"},
+		{"github.com/docker/distribution", "https://github.com/docker/distribution"},
+		{"sigs.k8s.io/yaml", "https://github.com/kubernetes-sigs/yaml"},
+		{"k8s.io/utils", "https://github.com/kubernetes/utils"},
+		{"k8s.io/client-go", "https://github.com/kubernetes/client-go"},
+		//{"gopkg.in/src-d/go-git.v4", "https://github.com/src-d/go-git"},
+		//{"golang.org/x/tools", "https://github.com/golang/tools"},
+		//{"golang.org/x/sync", "https://github.com/golang/sync"},
 	} {
 		git := getGitURL(tc.name)
 		if git != tc.git {


### PR DESCRIPTION
I noticed in https://github.com/containerd/containerd/pull/5003#issue-567898947 that `git://` was used, and recalled a recent tweet that it's insecure;

The git:// protocol is unencrypted like http://, and considered insecure.

ref: https://twitter.com/FiloSottile/status/1355201952313987073?s=20

<img width="400" alt="Screenshot 2021-02-05 at 15 11 35" src="https://user-images.githubusercontent.com/1804568/107044676-ec430c00-67c4-11eb-845f-c6cabf43ba0f.png">
