### PR TITLE
Add new contributor type

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,16 @@ type projectRename struct {
 	New string `toml:"new"`
 }
 
+type contributor struct {
+	Name    string
+	Email   string
+	Commits int
+
+	// OtherNames are names seen in the change log associated with
+	// the same email
+	OtherNames []string
+}
+
 type release struct {
 	ProjectName     string            `toml:"project_name"`
 	GithubRepo      string            `toml:"github_repo"`
@@ -84,7 +94,7 @@ type release struct {
 
 	// generated fields
 	Changes      []projectChange
-	Contributors []string
+	Contributors []contributor
 	Dependencies []dependency
 	Tag          string
 	Version      string
@@ -182,7 +192,7 @@ This tool should be ran from the root of the project repository for a new releas
 		gitConfigs["mailmap.file"] = mailmapPath
 
 		var (
-			contributors   = map[contributor]int{}
+			contributors   = map[string]contributor{}
 			projectChanges = []projectChange{}
 		)
 

--- a/template.go
+++ b/template.go
@@ -39,7 +39,7 @@ https://github.com/{{.GithubRepo}}/issues.
 
 ### Contributors
 {{range $contributor := .Contributors}}
-* {{$contributor}}
+* {{$contributor.Name}}
 {{- end -}}
 
 {{range $project := .Changes}}


### PR DESCRIPTION
Adds suggestions for duplicated names or emails for mailmap. This helps identify gaps in the mailmap in a long contributor list.

The new type will also help us make changes to the way we do contributor scoring in the future by allowing sorting on more than just the raw commit number.