### PR TITLE
Add PR title to changes output

### DIFF
--- a/template.go
+++ b/template.go
@@ -48,7 +48,7 @@ https://github.com/{{.GithubRepo}}/issues.
 <details><summary>{{len $project.Changes}} commit{{if gt (len $project.Changes) 1}}s{{end}}</summary>
 <p>
 {{range $change := $project.Changes }}
-* {{$change.Commit}} {{$change.Description}}
+{{$change}}
 {{- end}}
 </p>
 </details>


### PR DESCRIPTION
Order commits by merge commits and format merge commits with Github PR title.

This decreases the overall size of the output by removing the commit references for pull requests. For the example below, the size reduced from 126k to 96k for the full changelog.

See example output in https://gist.github.com/dmcgowan/12c3b551b97f126ce4b0034833ca3d5f by expanding commits