### PR TITLE
Update Github processing to add support for GHSA and shorten output

### DIFF
--- a/github.go
+++ b/github.go
@@ -1,0 +1,129 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+var prr = regexp.MustCompile(`^Merge pull request(?: #([0-9]+))? from (\S+)$`)
+
+type githubChangeProcessor struct {
+	repo  string
+	cache Cache // Need a way to expire or bypass cache
+}
+
+func githubChange(repo string, cache Cache) changeProcessor {
+	return &githubChangeProcessor{
+		repo:  repo,
+		cache: cache,
+	}
+}
+
+func (p *githubChangeProcessor) process(c *change) error {
+	if matches := prr.FindSubmatch([]byte(c.Description)); len(matches) == 3 {
+		if len(matches[1]) > 0 {
+			pr, err := strconv.ParseInt(string(matches[1]), 10, 64)
+			if err != nil {
+				return err
+			}
+
+			title, err := getPRTitle(p.repo, pr, p.cache)
+			if err != nil {
+				return err
+			}
+
+			c.Title = title
+			c.Link = fmt.Sprintf("https://github.com/%s/pull/%d", p.repo, pr)
+			c.Formatted = fmt.Sprintf("%s ([#%d](%s))", c.Title, pr, c.Link)
+		} else if strings.HasPrefix(string(matches[2]), "GHSA-") {
+			c.Link = fmt.Sprintf("https://github.com/%s/security/advisories/%s", p.repo, matches[2])
+			c.Formatted = fmt.Sprintf("Github Security Advisory [%s](%s)", matches[2], c.Link)
+		} else {
+			logrus.Debugf("Nothing matched: %q", c.Description)
+		}
+		c.IsMerge = true
+	} else if strings.HasPrefix(c.Description, "Merge") {
+		logrus.WithField("matches", matches).Debugf("Not matched: %q", c.Description)
+	}
+
+	if c.Formatted == "" {
+		full, err := git("rev-parse", c.Commit)
+		if err != nil {
+			return err
+		}
+		commit := strings.TrimSpace(string(full))
+
+		c.Link = fmt.Sprintf("https://github.com/%s/commit/%s", p.repo, commit)
+		c.Formatted = fmt.Sprintf("[`%s`](%s) %s", c.Commit, c.Link, c.Description)
+	}
+	return nil
+}
+
+// getPRTitle returns the Pull Request title from the github API
+// TODO: Update to also return labels
+func getPRTitle(repo string, prn int64, cache Cache) (string, error) {
+	u := fmt.Sprintf("https://api.github.com/repos/%s/pulls/%d", repo, prn)
+	key := u + " title"
+	if b, ok := cache.Get(key); ok { // TODO: Provide option to refresh cache
+		return string(b), nil
+	}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+	if user, token := os.Getenv("GITHUB_ACTOR"), os.Getenv("GITHUB_TOKEN"); user != "" && token != "" {
+		req.SetBasicAuth(user, token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		if resp.StatusCode >= 403 {
+			logrus.Warn("Forbidden response, try setting GITHUB_USER and GITHUB_TOKEN environment variables")
+		}
+		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, u)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+
+	pr := struct {
+		Title string `json:"title"`
+	}{}
+	if err := dec.Decode(&pr); err != nil {
+		return "", err
+	}
+	if pr.Title == "" {
+		return "", fmt.Errorf("unexpected empty title for %s", u)
+	}
+
+	cache.Put(key, []byte(pr.Title))
+	return pr.Title, nil
+}

--- a/github.go
+++ b/github.go
@@ -76,6 +76,7 @@ func (p *githubChangeProcessor) process(c *change) error {
 		}
 		commit := strings.TrimSpace(string(full))
 
+		c.Title = c.Description
 		c.Link = fmt.Sprintf("https://github.com/%s/commit/%s", p.repo, commit)
 		c.Formatted = fmt.Sprintf("[`%s`](%s) %s", c.Commit, c.Link, c.Description)
 	}

--- a/main.go
+++ b/main.go
@@ -148,6 +148,11 @@ This tool should be ran from the root of the project repository for a new releas
 			Aliases: []string{"l"},
 			Usage:   "add links to changelog",
 		},
+		&cli.BoolFlag{
+			Name:    "short",
+			Aliases: []string{"s"},
+			Usage:   "shorten changelog length where possible",
+		},
 		&cli.StringFlag{
 			Name:    "cache",
 			Usage:   "cache directory for static remote resources",
@@ -159,6 +164,7 @@ This tool should be ran from the root of the project repository for a new releas
 			releasePath = context.Args().First()
 			tag         = context.String("tag")
 			linkify     = context.Bool("linkify")
+			short       = context.Bool("short")
 		)
 		if tag == "" {
 			tag = parseTag(releasePath)
@@ -218,6 +224,9 @@ This tool should be ran from the root of the project repository for a new releas
 			for _, change := range changes {
 				if err := githubChange(r.GithubRepo, cache).process(change); err != nil {
 					return err
+				}
+				if short && !change.IsMerge {
+					change.Formatted = change.Title
 				}
 			}
 		} else {
@@ -327,6 +336,9 @@ This tool should be ran from the root of the project repository for a new releas
 						for _, change := range changes {
 							if err := githubChange(ghname, cache).process(change); err != nil {
 								return err
+							}
+							if short && !change.IsMerge {
+								change.Formatted = change.Title
 							}
 						}
 					}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,16 @@ type note struct {
 type change struct {
 	Commit      string `toml:"commit"`
 	Description string `toml:"description"`
+
+	Title    string
+	Category string
+	Link     string
+
+	IsMerge bool
+	//IsBreaking  bool
+	//IsHighlight bool
+
+	Formatted string
 }
 
 type dependency struct {
@@ -59,7 +69,7 @@ type download struct {
 
 type projectChange struct {
 	Name    string
-	Changes []string
+	Changes []*change
 }
 
 type projectRename struct {
@@ -78,14 +88,18 @@ type contributor struct {
 }
 
 type release struct {
-	ProjectName     string            `toml:"project_name"`
-	GithubRepo      string            `toml:"github_repo"`
-	Commit          string            `toml:"commit"`
-	Previous        string            `toml:"previous"`
-	PreRelease      bool              `toml:"pre_release"`
-	Preface         string            `toml:"preface"`
-	Notes           map[string]note   `toml:"notes"`
-	BreakingChanges map[string]change `toml:"breaking"`
+	ProjectName     string             `toml:"project_name"`
+	GithubRepo      string             `toml:"github_repo"`
+	Commit          string             `toml:"commit"`
+	Previous        string             `toml:"previous"`
+	PreRelease      bool               `toml:"pre_release"`
+	Preface         string             `toml:"preface"`
+	Notes           map[string]note    `toml:"notes"`
+	BreakingChanges map[string]*change `toml:"breaking"`
+
+	// highlight options
+	//HighlightLabel string   `toml:"highlight_label"`
+	//CategoryLabels []string `toml:"category_labels"`
 
 	// dependency options
 	MatchDeps  string                   `toml:"match_deps"`
@@ -200,17 +214,15 @@ This tool should be ran from the root of the project repository for a new releas
 		if err != nil {
 			return err
 		}
-		changeLines := make([]string, len(changes))
 		if linkify {
-			for i := range changes {
-				changeLines[i], err = linkifyChange(&changes[i], githubCommitLink(r.GithubRepo), githubPRLink(r.GithubRepo, cache))
-				if err != nil {
+			for _, change := range changes {
+				if err := githubChange(r.GithubRepo, cache).process(change); err != nil {
 					return err
 				}
 			}
 		} else {
-			for i, change := range changes {
-				changeLines[i] = fmt.Sprintf("* %s %s", change.Commit, change.Description)
+			for _, change := range changes {
+				change.Formatted = fmt.Sprintf("* %s %s", change.Commit, change.Description)
 			}
 		}
 		if err := addContributors(r.Previous, r.Commit, contributors); err != nil {
@@ -218,7 +230,7 @@ This tool should be ran from the root of the project repository for a new releas
 		}
 		projectChanges = append(projectChanges, projectChange{
 			Name:    "",
-			Changes: changeLines,
+			Changes: changes,
 		})
 
 		logrus.Infof("creating new release %s with %d new changes...", tag, len(changes))
@@ -307,28 +319,26 @@ This tool should be ran from the root of the project repository for a new releas
 				if err := addContributors(dep.Previous, dep.Ref, contributors); err != nil {
 					return errors.Wrapf(err, "failed to get authors for %s", name)
 				}
-				changeLines = make([]string, len(changes))
 				if linkify {
 					if !strings.HasPrefix(dep.Name, "github.com/") {
 						logrus.Debugf("linkify only supported for Github, skipping %s", dep.Name)
 					} else {
 						ghname := dep.Name[11:]
-						for i := range changes {
-							changeLines[i], err = linkifyChange(&changes[i], githubCommitLink(ghname), githubPRLink(ghname, cache))
-							if err != nil {
+						for _, change := range changes {
+							if err := githubChange(ghname, cache).process(change); err != nil {
 								return err
 							}
 						}
 					}
 				} else {
-					for i, change := range changes {
-						changeLines[i] = fmt.Sprintf("* %s %s", change.Commit, change.Description)
+					for _, change := range changes {
+						change.Formatted = fmt.Sprintf("* %s %s", change.Commit, change.Description)
 					}
 				}
 
 				projectChanges = append(projectChanges, projectChange{
 					Name:    name,
-					Changes: changeLines,
+					Changes: changes,
 				})
 
 			}

--- a/template.go
+++ b/template.go
@@ -48,7 +48,7 @@ https://github.com/{{.GithubRepo}}/issues.
 <details><summary>{{len $project.Changes}} commit{{if gt (len $project.Changes) 1}}s{{end}}</summary>
 <p>
 {{range $change := $project.Changes }}
-{{$change}}
+{{if not $change.IsMerge}}  {{end}}* {{$change.Formatted}}
 {{- end}}
 </p>
 </details>


### PR DESCRIPTION
Refactors Github processing into a separate component.
Adds logic to recognize Github Security Advisories.
Adds option to reduce overall output size by removing commit links under pull requests (needed for major release such as 1.6)