### PR TITLE
Fix go mod submodule git urls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       run: GOGC=75 golangci-lint run
       working-directory: src/github.com/containerd/release-tool
 
+    - name: Unit Test
+      working-directory: src/github.com/containerd/release-tool
+      run: |
+        go test -v .
+
     - name: Build
       working-directory: src/github.com/containerd/release-tool
       run: |

--- a/util.go
+++ b/util.go
@@ -248,11 +248,23 @@ func getGitURL(name string) string {
 	if idx := strings.Index(name, "/"); idx > 0 {
 		switch name[:idx] {
 		case "github.com":
-			return "https://" + name
+			parts := strings.Split(name, "/")
+			if parts < 3 {
+				return ""
+			}
+			return "https://" + strings.Join(name[0:3], "/")
 		case "k8s.io":
-			return "https://github.com/kubernetes" + name[idx:]
+			repo := name[idx+1:]
+			if i := strings.Index(repo, "/"); i > 0 {
+				repo = repo[:i]
+			}
+			return "https://github.com/kubernetes/" + repo
 		case "sigs.k8s.io":
-			return "https://github.com/kubernetes-sigs" + name[idx:]
+			repo := name[idx+1:]
+			if i := strings.Index(repo, "/"); i > 0 {
+				repo = repo[:i]
+			}
+			return "https://github.com/kubernetes-sigs/" + repo
 		case "gopkg.in":
 			// gopkg.in/pkg.v3      → github.com/go-pkg/pkg (branch/tag v3, v3.N, or v3.N.M)
 			// gopkg.in/user/pkg.v3 → github.com/user/pkg   (branch/tag v3, v3.N, or v3.N.M)

--- a/util.go
+++ b/util.go
@@ -249,10 +249,10 @@ func getGitURL(name string) string {
 		switch name[:idx] {
 		case "github.com":
 			parts := strings.Split(name, "/")
-			if parts < 3 {
+			if len(parts) < 3 {
 				return ""
 			}
-			return "https://" + strings.Join(name[0:3], "/")
+			return "https://" + strings.Join(parts[0:3], "/")
 		case "k8s.io":
 			repo := name[idx+1:]
 			if i := strings.Index(repo, "/"); i > 0 {
@@ -361,6 +361,37 @@ func parseChangelog(changelog []byte) ([]*change, error) {
 	return changes, nil
 }
 
+func nextGitURLTry(url string) string {
+	var prefix string
+	if strings.HasPrefix(url, "https://") {
+		prefix = "https://"
+		url = url[8:]
+	}
+	parts := strings.Split(url, "/")
+	if len(parts) < 3 {
+		return ""
+	}
+	return prefix + strings.Join(parts[:len(parts)-1], "/")
+}
+
+func lsRemote(key, gitURL, rev string) []byte {
+	for gitURL != "" {
+		b, err := git("ls-remote", gitURL, rev, rev+"^{}")
+		if err != nil {
+			// strip next ending to handle Go submodules
+			gitURL = nextGitURLTry(gitURL)
+			if !strings.Contains(err.Error(), "not found") {
+				logrus.WithError(err).WithField("key", key).Debug("not using sha")
+			}
+		} else {
+			return b
+		}
+
+	}
+	return nil
+
+}
+
 func getSha(gitURL, rev string, cache Cache) (string, error) {
 	key := fmt.Sprintf("git ls-remote %s %s %s^{}", gitURL, rev, rev)
 	if b, ok := cache.Get(key); ok {
@@ -369,9 +400,8 @@ func getSha(gitURL, rev string, cache Cache) (string, error) {
 	}
 	logrus.WithField("cache", "miss").Debug(key)
 
-	b, err := git("ls-remote", gitURL, rev, rev+"^{}")
-	if err != nil {
-		logrus.WithError(err).WithField("key", key).Debug("not using sha")
+	b := lsRemote(key, gitURL, rev)
+	if b == nil {
 		// Not found, don't use sha
 		return "", nil
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -48,8 +48,13 @@ func TestGetGitURL(t *testing.T) {
 	}{
 		{"github.com/docker/distribution", "https://github.com/docker/distribution"},
 		{"sigs.k8s.io/yaml", "https://github.com/kubernetes-sigs/yaml"},
+		{"sigs.k8s.io/yaml/v2", "https://github.com/kubernetes-sigs/yaml"},
 		{"k8s.io/utils", "https://github.com/kubernetes/utils"},
+		{"k8s.io/utils/v8", "https://github.com/kubernetes/utils"},
 		{"k8s.io/client-go", "https://github.com/kubernetes/client-go"},
+		{"github.com/someorg/somerepo/v2", "https://github.com/someorg/somerepo"},
+		{"github.com/someorg/somerepo/unnecessarysubmod", "https://github.com/someorg/somerepo"},
+		{"github.com/invalid", ""},
 		//{"gopkg.in/src-d/go-git.v4", "https://github.com/src-d/go-git"},
 		//{"golang.org/x/tools", "https://github.com/golang/tools"},
 		//{"golang.org/x/sync", "https://github.com/golang/sync"},


### PR DESCRIPTION
The release tools relies on git to resolve tags for dependencies. The git URLs are not provided by go mod and the formation of the URL can be incorrect today by not accounting for submodules or major version paths.