### PR TITLE
Remove references to io/ioutil

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/base32"
 	"hash/fnv"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -43,12 +43,12 @@ type dirCache struct {
 }
 
 func (dc *dirCache) Get(key string) ([]byte, bool) {
-	b, err := ioutil.ReadFile(dc.path(key))
+	b, err := os.ReadFile(dc.path(key))
 	return b, err == nil
 }
 
 func (dc *dirCache) Put(key string, value []byte) error {
-	return ioutil.WriteFile(dc.path(key), value, 0755)
+	return os.WriteFile(dc.path(key), value, 0755)
 }
 
 func (dc *dirCache) path(key string) string {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -269,7 +268,7 @@ This tool should be ran from the root of the project repository for a new releas
 				return errors.Wrap(err, "unable to compile 'match_deps' regexp")
 			}
 			if gitRoot == "" {
-				td, err := ioutil.TempDir("", "tmp-clone-")
+				td, err := os.MkdirTemp("", "tmp-clone-")
 				if err != nil {
 					return errors.Wrap(err, "unable to create temp clone directory")
 				}

--- a/util.go
+++ b/util.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -122,7 +121,7 @@ func parseModulesTxtDependencies(r io.Reader) ([]dependency, error) {
 func parseGoModDependencies(r io.Reader) ([]dependency, error) {
 	var err error
 
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +642,7 @@ func getTemplate(context *cli.Context) (string, error) {
 		return "", err
 	}
 	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
io/ioutil has been marked deprecated since Go 1.16

Signed-off-by: Austin Vazquez <macedonv@amazon.com>