### PR TITLE
Allow overriding the previous commit for a dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ type dependency struct {
 	Sha      string
 	Previous string
 	GitURL   string
+	New      bool
 }
 
 type download struct {
@@ -73,6 +74,10 @@ type projectChange struct {
 type projectRename struct {
 	Old string `toml:"old"`
 	New string `toml:"new"`
+}
+
+type dependencyOverride struct {
+	Previous string `toml:"previous"`
 }
 
 type contributor struct {
@@ -101,9 +106,10 @@ type release struct {
 	//CategoryLabels []string `toml:"category_labels"`
 
 	// dependency options
-	MatchDeps  string                   `toml:"match_deps"`
-	RenameDeps map[string]projectRename `toml:"rename_deps"`
-	IgnoreDeps []string                 `toml:"ignore_deps"`
+	MatchDeps    string                        `toml:"match_deps"`
+	RenameDeps   map[string]projectRename      `toml:"rename_deps"`
+	IgnoreDeps   []string                      `toml:"ignore_deps"`
+	OverrideDeps map[string]dependencyOverride `toml:"override_deps"`
 
 	// generated fields
 	Changes      []projectChange
@@ -255,6 +261,7 @@ This tool should be ran from the root of the project repository for a new releas
 		if err != nil {
 			return err
 		}
+		overrideDependencies(current, r.OverrideDeps)
 
 		previous, err := parseDependencies(r.Previous)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -105,10 +105,17 @@ type release struct {
 	//HighlightLabel string   `toml:"highlight_label"`
 	//CategoryLabels []string `toml:"category_labels"`
 
-	// dependency options
-	MatchDeps    string                        `toml:"match_deps"`
-	RenameDeps   map[string]projectRename      `toml:"rename_deps"`
-	IgnoreDeps   []string                      `toml:"ignore_deps"`
+	// MatchDeps provides a regex string to match dependencies to be
+	// included as part of the changelog.
+	MatchDeps string `toml:"match_deps"`
+	// RenameDeps provides a way to match dependencies which have been
+	// renamed from the old name to the new name.
+	RenameDeps map[string]projectRename `toml:"rename_deps"`
+	// IgnoreDeps are dependencies to ignore from the output.
+	IgnoreDeps []string `toml:"ignore_deps"`
+	// OverrideDeps is used to override the current dependency calculated
+	// from the dependency list. This can be used to set the previous version
+	// which could be missing for new or moved dependencies.
 	OverrideDeps map[string]dependencyOverride `toml:"override_deps"`
 
 	// generated fields

--- a/template.go
+++ b/template.go
@@ -59,7 +59,7 @@ https://github.com/{{.GithubRepo}}/issues.
 ### Dependency Changes
 {{if .Dependencies}}
 {{- range $dep := .Dependencies}}
-* **{{$dep.Name}}**	{{if $dep.Previous}}{{$dep.Previous}} -> {{$dep.Ref}}{{else}}{{$dep.Ref}} **_new_**{{end}}
+* **{{$dep.Name}}**	{{if $dep.New}}{{$dep.Ref}} **_new_**{{else}}{{$dep.Previous}} -> {{$dep.Ref}}{{end}}
 {{- end}}
 {{- else}}
 This release has no dependency changes


### PR DESCRIPTION
We need to be able to handle when a library is split out into an external dependency. Currently that dependency will show up with all its commits seen as new for inclusion. The dependency overrides lets us choose the previous commit to use for the release to only include commits since then.