### PR TITLE
Add info from Github pull requests and security advisories

### DIFF
--- a/template.go
+++ b/template.go
@@ -27,6 +27,21 @@ Welcome to the {{.Tag}} release of {{.ProjectName}}!
 
 {{.Preface}}
 
+{{- if .Highlights}}
+
+### Highlights
+{{- range $highlight := .Highlights}}
+
+{{- if $highlight.Name}}
+
+#### {{$highlight.Name}}
+{{- end}}
+{{ range $change := $highlight.Changes}}
+* {{ $change.Change.Formatted }}
+{{- end}}
+{{- end}}
+{{- end}}
+
 Please try out the release binaries and report any issues at
 https://github.com/{{.GithubRepo}}/issues.
 


### PR DESCRIPTION
Add highlights to template and option to use highlights.

 This pull requests uses labels on the pull requests to get the highlight changelog lines and group the changes based on the `area/` labels. It recognizes `impact/changelog`, `impact/breaking`, and `impact/deprecation`. It also adds a security category for Github Security Advisories.