### PR TITLE
Fix release tool issues

### DIFF
--- a/github.go
+++ b/github.go
@@ -110,7 +110,7 @@ func (p *githubChangeProcessor) prChange(c *change, info pullRequestInfo, pr int
 	if len(c.Title) > 0 && c.Title[0] == '[' {
 		idx := strings.IndexByte(c.Title, ']')
 		if idx > 0 {
-			c.Title = strings.TrimSpace(c.Title[idx:])
+			c.Title = strings.TrimSpace(c.Title[idx+1:])
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -415,7 +415,8 @@ This tool should be ran from the root of the project repository for a new releas
 		r.Dependencies = updatedDeps
 		if highlights {
 			r.Highlights = groupHighlights(projectChanges)
-		} else {
+		}
+		if !highlights || !skipCommits {
 			r.Changes = projectChanges
 		}
 		r.Tag = tag


### PR DESCRIPTION
Fix an issue with `]` not getting stripped in titles like `[release/1.6]`
Fix an issue where the changelog with commits its not included when highlights flag is set even though skip commits is not set.