### PR TITLE
Clean up app name/description in help output

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,10 +142,10 @@ type release struct {
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "release"
-	app.Description = `release tooling.
+	app.Name = "release-tool"
+	app.Description = `release tooling to create annotated GitHub release notes.
 
-This tool should be ran from the root of the project repository for a new release.
+This tool should run from the root of the project repository for a new release.
 `
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{


### PR DESCRIPTION
Help output is slightly confusing as it says the name of the tool is "release" and not "release-tool"; also cleaned up some grammar/wording.