### PR TITLE
Update go.mod to make Go happier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/containerd/release-tool
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/pelletier/go-toml/v2 v2.0.5


### PR DESCRIPTION
The dependabot change forces the additional lines in go.mod based on updating to a recent Go release. With this change the dependabot PRs can hopefully pass CI