### PR TITLE
Make highlight titles bold

### DIFF
--- a/github.go
+++ b/github.go
@@ -123,7 +123,7 @@ func (p *githubChangeProcessor) prChange(c *change, info pullRequestInfo, pr int
 	if releaseNote != "" {
 		c.Highlight = fmt.Sprintf("%s ([%s#%d](%s))", releaseNote, p.linkName, pr, c.Link)
 	} else {
-		c.Highlight = c.Formatted
+		c.Highlight = fmt.Sprintf("**%s** ([%s#%d](%s))", c.Title, p.linkName, pr, c.Link)
 	}
 
 }


### PR DESCRIPTION
Bold text better matches the formatting of the titles. I thought we used to do it this way, but it looks better than how it renders now. This also allows highlights to add text that can be differentiated from the titles around it.

Without bold in latest 2.2 rc
https://github.com/containerd/containerd/releases/tag/v2.2.0-rc.0

With manually bold in 1.6
https://github.com/containerd/containerd/releases/tag/v1.6.0