### PR TITLE
util: accept go-import meta tags with a subdirectory

### DIFF
--- a/util.go
+++ b/util.go
@@ -797,16 +797,30 @@ func resolveGitURL(name string, cache Cache) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, u)
 	}
 
-	t := html.NewTokenizer(resp.Body)
+	resolved, err := parseGoImportGitURL(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	cache.Put(u, []byte(resolved))
+	return resolved, nil
+}
+
+// parseGoImportGitURL returns the repository URL from the go-import meta tag
+// of an HTML document. The content of the tag is "prefix vcs repo-root" with
+// an optional fourth field naming the subdirectory of the repository the
+// module lives in.
+func parseGoImportGitURL(r io.Reader) (string, error) {
+	t := html.NewTokenizer(r)
 	for {
 		switch t.Next() {
 		case html.ErrorToken:
 			err := t.Err()
-			if err == nil {
+			if err == nil || errors.Is(err, io.EOF) {
 				err = errors.New("no go-import meta tag")
 			}
 			return "", err
@@ -825,10 +839,8 @@ func resolveGitURL(name string, cache Cache) (string, error) {
 			}
 			if name == "go-import" {
 				parts := strings.Fields(content)
-				if len(parts) == 3 && parts[1] == "git" {
-					resolved := parts[2]
-					cache.Put(u, []byte(resolved))
-					return resolved, nil
+				if (len(parts) == 3 || len(parts) == 4) && parts[1] == "git" {
+					return parts[2], nil
 				}
 			}
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseModuleCommit(t *testing.T) {
 	for i, tc := range []struct {
@@ -93,4 +96,58 @@ func TestReleaseNote(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParseGoImportGitURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		doc  string
+		git  string
+		err  string
+	}{
+		{
+			name: "repo root",
+			doc:  `<html><head><meta name="go-import" content="go.opentelemetry.io/otel git https://github.com/open-telemetry/opentelemetry-go"></head></html>`,
+			git:  "https://github.com/open-telemetry/opentelemetry-go",
+		},
+		{
+			name: "subdirectory",
+			doc: `<html><head>
+<meta name="go-import" content="cyphar.com/go-pathrs git https://github.com/cyphar/libpathrs.git go-pathrs">
+<meta name="go-source" content="cyphar.com/go-pathrs https://github.com/cyphar/libpathrs {repo}/tree/{commit}/go-pathrs{/dir} {repo}/blob/{commit}/go-pathrs/{file}#L{line}">
+</head></html>`,
+			git: "https://github.com/cyphar/libpathrs.git",
+		},
+		{
+			name: "too many fields",
+			doc:  `<html><head><meta name="go-import" content="example.com/mod git https://example.com/mod.git sub extra"></head></html>`,
+			err:  "no go-import meta tag",
+		},
+		{
+			name: "not git",
+			doc:  `<html><head><meta name="go-import" content="example.com/mod mod https://example.com/proxy"></head></html>`,
+			err:  "no go-import meta tag",
+		},
+		{
+			name: "no meta tag",
+			doc:  `<html><head><title>nothing here</title></head></html>`,
+			err:  "no go-import meta tag",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			git, err := parseGoImportGitURL(strings.NewReader(tc.doc))
+			if tc.err != "" {
+				if err == nil || err.Error() != tc.err {
+					t.Fatalf("unexpected error %v, expected %q", err, tc.err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if git != tc.git {
+				t.Fatalf("unexpected git url %q, expected %q", git, tc.git)
+			}
+		})
+	}
 }


### PR DESCRIPTION
A module that does not live at the root of its repository advertises a go-import meta tag with a fourth field naming the subdirectory, as cyphar.com/go-pathrs does. Only the three field form was accepted, so the tag was skipped and the io.EOF of the exhausted tokenizer was reported as the failure:

  git url for cyphar.com/go-pathrs: EOF

Accept both forms, as the go command does, and report an exhausted document as the "no go-import meta tag" error that could not be reached before. Tag parsing moves into its own function so it can be tested without network access, and the response body is now closed.