### PR TITLE
util: accept go-import tags with extra fields

### DIFF
--- a/util.go
+++ b/util.go
@@ -801,7 +801,18 @@ func resolveGitURL(name string, cache Cache) (string, error) {
 		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, u)
 	}
 
-	t := html.NewTokenizer(resp.Body)
+	resolved, err := parseGoImportGitURL(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	cache.Put(u, []byte(resolved))
+	return resolved, nil
+}
+
+// parseGoImportGitURL returns the repository root from the first go-import
+// meta tag using git as the version control system.
+func parseGoImportGitURL(r io.Reader) (string, error) {
+	t := html.NewTokenizer(r)
 	for {
 		switch t.Next() {
 		case html.ErrorToken:
@@ -825,10 +836,8 @@ func resolveGitURL(name string, cache Cache) (string, error) {
 			}
 			if name == "go-import" {
 				parts := strings.Fields(content)
-				if len(parts) == 3 && parts[1] == "git" {
-					resolved := parts[2]
-					cache.Put(u, []byte(resolved))
-					return resolved, nil
+				if len(parts) >= 3 && parts[1] == "git" {
+					return parts[2], nil
 				}
 			}
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseModuleCommit(t *testing.T) {
 	for i, tc := range []struct {
@@ -66,6 +69,60 @@ func TestGetGitURL(t *testing.T) {
 
 	}
 
+}
+
+func TestParseGoImportGitURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		html string
+		git  string
+	}{
+		{
+			name: "three fields",
+			html: `<meta name="go-import" content="sigs.k8s.io/yaml git https://github.com/kubernetes-sigs/yaml">`,
+			git:  "https://github.com/kubernetes-sigs/yaml",
+		},
+		{
+			name: "more than three fields",
+			html: `<meta name="go-import" content="cyphar.com/go-pathrs git https://github.com/cyphar/libpathrs go-pathrs">`,
+			git:  "https://github.com/cyphar/libpathrs",
+		},
+		{
+			name: "full document",
+			html: `<html><head><meta name="go-source" content="cyphar.com/go-pathrs _ _ _">` +
+				`<meta name="go-import" content="cyphar.com/go-pathrs git https://github.com/cyphar/libpathrs go-pathrs">` +
+				`</head><body>nothing to see here</body></html>`,
+			git: "https://github.com/cyphar/libpathrs",
+		},
+		{
+			name: "not git",
+			html: `<meta name="go-import" content="example.com/hg hg https://example.com/hg">`,
+		},
+		{
+			name: "too few fields",
+			html: `<meta name="go-import" content="example.com/short git">`,
+		},
+		{
+			name: "no go-import",
+			html: `<html><head><meta name="go-source" content="example.com/none _ _ _"></head></html>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			git, err := parseGoImportGitURL(strings.NewReader(tc.html))
+			if tc.git == "" {
+				if err == nil {
+					t.Fatalf("expected error, got git url %q", git)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if git != tc.git {
+				t.Errorf("unexpected git url %q, expected %q", git, tc.git)
+			}
+		})
+	}
 }
 
 func TestReleaseNote(t *testing.T) {


### PR DESCRIPTION
The content of a go-import meta tag can carry more than the three documented tokens. cyphar.com/go-pathrs, for instance, appends the module subdirectory:

  <meta name="go-import" content="cyphar.com/go-pathrs git https://github.com/cyphar/libpathrs go-pathrs">

Requiring exactly three fields skips such a tag, so the tokenizer runs to the end of the document and resolveGitURL fails with a bare "EOF" rather than returning the repository URL.

Move the tag scanning into parseGoImportGitURL so that it can be exercised without network access.


Assisted-by: Antigravity